### PR TITLE
[Refact] Extrair Metodo

### DIFF
--- a/trabalho-tdd/patex/src/main/java/com/tppe/tdd/patex/Patex.java
+++ b/trabalho-tdd/patex/src/main/java/com/tppe/tdd/patex/Patex.java
@@ -120,13 +120,13 @@ public class Patex {
         boolean wordBeforeWasNumber = false;
         outputFile.write("Evolution number" + this.delimiter + "value" + "\n");
         for (String word : this.chosenFileLines) {
-            if(word.matches("(-)*[ Eevolucçãaotion]+(.)*")){
-                String[] splitted = word.split(" ");
-                String evolution = splitted[splitted.length - 2];
+            if(isEvolution(word)){
+                String[] splitted = splitSpaces(word);
+                String evolution = getEvolutionNumber(splitted);
                 outputFile.write("\n" + evolution + this.delimiter);
                 wordBeforeWasNumber = false;
             }
-            else if(word.matches("[0-9]+(\\.[0-9]+)?")){
+            else if(isAnalysisValue(word)){
                 String sequence = wordBeforeWasNumber ? (this.delimiter + word) : word;
                 outputFile.write(sequence);
                 wordBeforeWasNumber = true;
@@ -134,6 +134,22 @@ public class Patex {
         }
         outputFile.close();
         return;
+    }
+
+    private String getEvolutionNumber(String[] splitted) {
+        return splitted[splitted.length - 2];
+    }
+
+    private String[] splitSpaces(String word) {
+        return word.split(" ");
+    }
+
+    private boolean isAnalysisValue(String word) {
+        return word.matches("[0-9]+(\\.[0-9]+)?");
+    }
+
+    private boolean isEvolution(String word) {
+        return word.matches("(-)*[ Eevolucçãaotion]+(.)*");
     }
 
     private void parseColumns(FileWriter outputFile) throws IOException {
@@ -145,13 +161,13 @@ public class Patex {
         this.matrizValues.add( new ArrayList<String>() );
 
         for (String word : this.chosenFileLines) {
-            if(word.matches("(-)*[ Eevolucçãaotion]+(.)*")){
-                String[] splitted = word.split(" ");
-                column = Integer.parseInt(splitted[splitted.length - 2]);
+            if(isEvolution(word)){
+                String[] splitted = splitSpaces(word);
+                column = Integer.parseInt(getEvolutionNumber(splitted));
                 line = 0;
                 this.matrizValues.get(0).add(Integer.toString(column));
             }
-            else if(word.matches("[0-9]+(\\.[0-9]+)?")){
+            else if(isAnalysisValue(word)){
                 ++line;
                 /* Caso a linha seja null , significa que todas as evolucoes anteriores sao menores que a atual e devem
                  ser null nessa linha */


### PR DESCRIPTION
Resolve parcialmente #4 

**O que foi feito ?**

[Refact] Extrair Metodo

Origem: Patex.java

Impactos: Patex.java - parseLines, parseColumns, getEvolutionNumber, splitSpaces,
isAnalysisValue, isEvolution

Explicacao: os metodos parseLines e parseColumns sao muito parecidos, porem nao
ha uma forma facil de extrai-los. Por isso alguns trechos deles foram modificados,
o que gerou a extracao de 4 novos metodos: getEvolutionNumber, splitSpaces,
isAnalysisValue e isEvolution. Os 2 ultimos sao relativos as expressoes regulares
para identificacao dos valores e dos numeros das evolucoes. O splitSpaces divide
uma palavra em sequencias a partir do caractere de espaco. Ja o getEvolutionNumber
usa o resultado do metodo anterior para extrair o numero daquela evolucao.

**Acceptance criteria**

- [x] All tests must still be running and getting accepted
- [x] Commit message styled correctly