### PR TITLE
[Refact] Extrair Classe

### DIFF
--- a/trabalho-tdd/patex/src/main/java/com/tppe/tdd/patex/Patex.java
+++ b/trabalho-tdd/patex/src/main/java/com/tppe/tdd/patex/Patex.java
@@ -3,7 +3,6 @@ package com.tppe.tdd.patex;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +23,7 @@ public class Patex {
     List<String> chosenFileLines;
     String outputPath;
     ArrayList<ArrayList> matrizValues;
+    Persistence persistence;
 
     Patex(){
         this.fc = new JFileChooser();
@@ -33,7 +33,8 @@ public class Patex {
         this.chosenFileLines = null;
         this.outputPath = null;
         this.setOutputFormatchoices();
-        matrizValues = new ArrayList<ArrayList>();
+        this.matrizValues = new ArrayList<ArrayList>();
+        this.persistence = new Persistence();
     }
 
     Patex(String pathToFile){
@@ -44,7 +45,8 @@ public class Patex {
         this.chosenFileLines = null;
         this.outputPath = null;
         this.setOutputFormatchoices();
-        matrizValues = new ArrayList<ArrayList>();
+        this.matrizValues = new ArrayList<ArrayList>();
+        this.persistence = new Persistence();
     }
 
     Patex(String pathToFile, String delimiter){
@@ -55,7 +57,8 @@ public class Patex {
         this.chosenFileLines = null;
         this.outputPath = null;
         this.setOutputFormatchoices();
-        matrizValues = new ArrayList<ArrayList>();
+        this.matrizValues = new ArrayList<ArrayList>();
+        this.persistence = new Persistence();
     }
 
     private void setOutputFormatchoices() {
@@ -74,17 +77,6 @@ public class Patex {
 
     Boolean isChosenFileReadable() {
         return chosenFile.canRead();
-    }
-
-    Boolean readChosenFile() throws Exception {
-        if(this.isFileChosen() && this.isChosenFileReadable()){
-            this.chosenFileLines = Files.readAllLines(
-                this.chosenFile.toPath().toAbsolutePath()
-            );
-            return true;
-        }
-
-        throw new Exception("File was not chosen or is not readable");
     }
 
     Boolean isOutputPathSet() {
@@ -114,16 +106,6 @@ public class Patex {
     Boolean wasChosenFileRead() {
         return this.chosenFileLines != null;
     }
-
-    Boolean writeToOutputFile() throws Exception {
-        if(this.wasChosenFileRead() && this.isOutputFormatChosen() && this.isOutputPathSet()) 
-            return new Parser(this).writeToOutputFIle();
-
-        throw new Exception(
-            "You must choose the path to save the output file before"
-        );
-    }
-
 
     Boolean choseOutputFormat() throws Exception {
         if(!this.isOutputFormatChosen()){
@@ -207,8 +189,8 @@ public class Patex {
             this.chooseDelimiter();
             this.OutputPathChoose();
             this.choseOutputFormat();
-            this.readChosenFile();
-            this.writeToOutputFile();
+            this.persistence.readChosenFile(this);
+            this.persistence.writeToOutputFile(this);
         } catch (FileNotFoundException e){
             JOptionPane.showMessageDialog(null, "You must choose a file to continue");
         } catch (DelimitadorInvalidoException e){

--- a/trabalho-tdd/patex/src/main/java/com/tppe/tdd/patex/Persistence.java
+++ b/trabalho-tdd/patex/src/main/java/com/tppe/tdd/patex/Persistence.java
@@ -1,0 +1,31 @@
+package com.tppe.tdd.patex;
+
+import java.nio.file.Files;
+
+public class Persistence {
+
+
+    Persistence(){
+
+    }
+
+   Boolean readChosenFile(Patex patex) throws Exception {
+       if(patex.isFileChosen() && patex.isChosenFileReadable()){
+           patex.chosenFileLines = Files.readAllLines(
+               patex.chosenFile.toPath().toAbsolutePath()
+           );
+           return true;
+       }
+
+       throw new Exception("File was not chosen or is not readable");
+   }
+
+    Boolean writeToOutputFile(Patex patex) throws Exception {
+        if(patex.wasChosenFileRead() && patex.isOutputFormatChosen() && patex.isOutputPathSet())
+            return new Parser(patex).writeToOutputFIle();
+
+        throw new Exception(
+            "You must choose the path to save the output file before"
+        );
+    }
+}

--- a/trabalho-tdd/patex/src/test/java/com/tppe/tdd/patex/ReadFileTest.java
+++ b/trabalho-tdd/patex/src/test/java/com/tppe/tdd/patex/ReadFileTest.java
@@ -13,18 +13,18 @@ public class ReadFileTest extends ChooseFileTest {
     @Test()
     void testFileWasRead() throws Exception {
         this.patexapp = new Patex("../analysisMemory.out");
-        assertEquals(true, this.patexapp.readChosenFile());
+        assertEquals(true, this.patexapp.persistence.readChosenFile(this.patexapp));
     }
 
     @Test()
     void testAnotherFileWasRead() throws Exception {
         this.patexapp = new Patex("../analysisTime.out");
-        assertEquals(true, this.patexapp.readChosenFile());
+        assertEquals(true, this.patexapp.persistence.readChosenFile(this.patexapp));
     }
 
     @Test()
     void testExceptionIsThrownWhenFileDoesNotExist() throws Exception {
         this.patexapp = new Patex("../imaginaryFile.txt");
-        assertThrows(Exception.class, () -> this.patexapp.readChosenFile());
+        assertThrows(Exception.class, () -> this.patexapp.persistence.readChosenFile(this.patexapp));
     }
 }

--- a/trabalho-tdd/patex/src/test/java/com/tppe/tdd/patex/WriteToOutuputFileTest.java
+++ b/trabalho-tdd/patex/src/test/java/com/tppe/tdd/patex/WriteToOutuputFileTest.java
@@ -19,8 +19,8 @@ public class WriteToOutuputFileTest extends ChooseFileTest {
         this.patexapp = new Patex("../analysisTime.out", ";");
         this.patexapp.userOutputFormatChoice = "Lines";
         this.patexapp.outputPath = this.testFile.getAbsolutePath();
-        this.patexapp.readChosenFile();
-        assertEquals(true, this.patexapp.writeToOutputFile());
+        this.patexapp.persistence.readChosenFile(this.patexapp);
+        assertEquals(true, this.patexapp.persistence.writeToOutputFile(this.patexapp));
     }
 
     @Test()
@@ -28,8 +28,8 @@ public class WriteToOutuputFileTest extends ChooseFileTest {
         this.patexapp = new Patex("../analysisMemory.out", ";");
         this.patexapp.userOutputFormatChoice = "Lines";
         this.patexapp.outputPath = this.testFile.getAbsolutePath();
-        this.patexapp.readChosenFile();
-        assertEquals(true, this.patexapp.writeToOutputFile());
+        this.patexapp.persistence.readChosenFile(this.patexapp);
+        assertEquals(true, this.patexapp.persistence.writeToOutputFile(this.patexapp));
     }
 
     @Test()
@@ -37,8 +37,8 @@ public class WriteToOutuputFileTest extends ChooseFileTest {
         this.patexapp = new Patex("../analysisTime.out", ";");
         this.patexapp.userOutputFormatChoice = "Columns";
         this.patexapp.outputPath = this.testFile.getAbsolutePath();
-        this.patexapp.readChosenFile();
-        assertEquals(true, this.patexapp.writeToOutputFile());
+        this.patexapp.persistence.readChosenFile(this.patexapp);
+        assertEquals(true, this.patexapp.persistence.writeToOutputFile(this.patexapp));
     }
 
     @Test()
@@ -46,7 +46,7 @@ public class WriteToOutuputFileTest extends ChooseFileTest {
         this.patexapp = new Patex("../analysisMemory.out", ";");
         this.patexapp.userOutputFormatChoice = "Columns";
         this.patexapp.outputPath = this.testFile.getAbsolutePath();
-        this.patexapp.readChosenFile();
-        assertEquals(true, this.patexapp.writeToOutputFile());
+        this.patexapp.persistence.readChosenFile(this.patexapp);
+        assertEquals(true, this.patexapp.persistence.writeToOutputFile(this.patexapp));
     }
 }


### PR DESCRIPTION
Termina de resolver #4 

Essa refatoração foi feita durante **pareamento** entre Erick e Murilo,
via Google Meet e compartilhamento de tela.

**O que foi feito ?**

[Refact] Extrair Classe

Origem: Patex.java

Impactos: Patex.java - readChosenFile, writeToOutputFile;
Persistence.java - readChosenFile, writeToOutputFile;
WriteToOutuputFileTest.java - testWriteToOutputFile_Lines, testWriteToOutputFile_Lines2,
testWriteToOutputFile_Columns, testWriteToOutputFile_Columns2;
ReadFileTest.java - testFileWasRead, testAnotherFileWasRead, testExceptionIsThrownWhenFileDoesNotExist.

Explicacao: Os metodos de leitura (readChosenFile) e de escrita (writeToOutputFile) foram
movidos da classe Patex.java para a Persistence.java. Esta tem uma indirecao para a classe
Parser.java em relacao ao metodo de escrita (writeToOutputFile), porque isso eh resultado
da refatoracao anterior (Subs. Metodo por Obj. Metodo). Nao houve elementos da classe de
origem (Patex) movidos para a nova classe (Persistence), pois tais atributos sao usados em
outros metodos da Patex. Alem disso, alguns metodos das classes de teste
(WriteToOutuputFileTest.java e ReadFileTest.java) sofreram leves modificacoes como resultado
dessa refatoracao.

Co-authored-by: Murilo Schiler <muriloschiler.ls@gmail.com>

**Acceptance criteria**

- [x] All tests must still be running and getting accepted
- [x] Commit message styled correctly